### PR TITLE
Fix logo path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,8 @@ Description: Package website colours and logos taken from the Imperial
     College London and Jameel Institute brand guidelines.
 License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
     license
+URL: https://github.com/j-idea/jameel-institute/jameelinst.rpkg.theme,
+    https://jameel-institute.github.io/jameelinst.rpkg.theme
 Imports: 
     pkgdown (>= 2.1.0)
 Encoding: UTF-8

--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -7,7 +7,7 @@ template:
   light-switch: true
   theme-dark: github-dark
   includes:
-    before_title: '<a href="https://www.imperial.ac.uk/jameel-institute/"><img src="https://github.com/jameel-institute/jameelinst.rpkg.theme.github.io/logo_imperial_white.svg" id="logo" alt="Abdul Latif Jameel Institute for Disease and Emergency Analytics"></a>'
+    before_title: '<a href="https://www.imperial.ac.uk/jameel-institute/"><img src="https://raw.githubusercontent.com/jameel-institute/jameelinst.rpkg.theme/refs/heads/main/inst/pkgdown/assets/logo_imperial_white.svg" id="logo" alt="Abdul Latif Jameel Institute for Disease and Emergency Analytics"></a>'
 
 development:
   mode: auto


### PR DESCRIPTION
This PR is a follow up to #2 which fixes the logo path in `inst/pkgdown/_pkgdownl.yml`. Verified to work on the {daedalus} website.