### PR TITLE
Use mathjax math rendering

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -6,6 +6,7 @@ template:
     code_font: {google: "Source Code Pro"}
   light-switch: true
   theme-dark: github-dark
+  math-rendering: mathjax
   includes:
     before_title: '<a href="https://www.imperial.ac.uk/jameel-institute/"><img src="https://raw.githubusercontent.com/jameel-institute/jameelinst.rpkg.theme/refs/heads/main/inst/pkgdown/assets/logo_imperial_jameel.svg" id="logo" alt="Abdul Latif Jameel Institute for Disease and Emergency Analytics"></a>'
 


### PR DESCRIPTION
We use a good amount of mathematical notation and the daedalus website isn't rendering that correctly. This PR should fix the issue based on what I've seen in https://github.com/r-lib/pkgdown/issues/2704 and https://github.com/epiforecasts/scoringutils/issues/1002.